### PR TITLE
feat: optimize pagination and reuse HTTP sessions

### DIFF
--- a/yonote_cli/setup.py
+++ b/yonote_cli/setup.py
@@ -6,7 +6,7 @@ setup(
     description="Self-contained CLI for Yonote (import/export)",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[],
+    install_requires=["requests"],
     entry_points={
         "console_scripts": [
             "yonote=yonote_cli.__main__:main",

--- a/yonote_cli/yonote_cli/core/cache.py
+++ b/yonote_cli/yonote_cli/core/cache.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List
 
-from .config import CACHE_PATH, API_MAX_LIMIT
+from .config import CACHE_PATH
 from .utils import fetch_all_concurrent
 
 
@@ -43,7 +43,6 @@ def list_documents_in_collection(
         token,
         "/documents.list",
         params={"collectionId": collection_id},
-        limit=API_MAX_LIMIT,
         workers=workers,
         desc="Fetch docs",
     )

--- a/yonote_cli/yonote_cli/core/http.py
+++ b/yonote_cli/yonote_cli/core/http.py
@@ -3,84 +3,66 @@
 from __future__ import annotations
 
 import json
-import uuid
 import sys
 from typing import Any, Dict
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+
+import requests
+
+
+_session = requests.Session()
 
 
 def http_json(method: str, url: str, token: str, payload: Dict[str, Any] | None = None) -> Dict[str, Any] | bytes:
     headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
-    data = None
-    if payload is not None:
-        headers["Content-Type"] = "application/json"
-        data = json.dumps(payload).encode("utf-8")
-    req = Request(url=url, method=method.upper(), headers=headers, data=data)
     try:
-        with urlopen(req, timeout=60) as resp:
-            ctype = (resp.headers.get("Content-Type") or "").lower()
-            raw = resp.read()
-            if "application/json" in ctype:
-                try:
-                    return json.loads(raw.decode("utf-8"))
-                except Exception:
-                    return raw
-            return raw
-    except HTTPError as e:
-        body = e.read().decode("utf-8", errors="ignore")
-        print(f"[HTTP {e.code}] {body}", file=sys.stderr)
+        resp = _session.request(
+            method.upper(),
+            url,
+            json=payload,
+            headers=headers,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        ctype = (resp.headers.get("Content-Type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                return resp.json()
+            except Exception:
+                return resp.content
+        return resp.content
+    except requests.HTTPError as e:
+        body = e.response.text if e.response is not None else ""
+        print(f"[HTTP {e.response.status_code if e.response else '??'}] {body}", file=sys.stderr)
         sys.exit(2)
-    except URLError as e:
-        print(f"Network error: {e.reason}", file=sys.stderr)
+    except requests.RequestException as e:
+        print(f"Network error: {e}", file=sys.stderr)
         sys.exit(2)
 
 
 def http_multipart_post(url: str, token: str, fields: Dict[str, object]) -> Dict[str, Any] | bytes:
-    boundary = f"----yonotecli{uuid.uuid4().hex}"
-
-    def to_b(x):
-        return x if isinstance(x, (bytes, bytearray)) else str(x).encode("utf-8")
-
-    parts: list[bytes] = []
+    data: Dict[str, Any] = {}
+    files: Dict[str, Any] = {}
     for name, value in (fields or {}).items():
-        parts.append(f"--{boundary}\r\n".encode())
         if isinstance(value, tuple):
             filename, content, ctype = value
-            if ctype is None:
-                import mimetypes
-                ctype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
-            parts.append(f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode())
-            parts.append(f"Content-Type: {ctype}\r\n\r\n".encode())
-            parts.append(to_b(content))
-            parts.append(b"\r\n")
+            files[name] = (filename, content, ctype)
         else:
-            parts.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
-            parts.append(to_b(value))
-            parts.append(b"\r\n")
-    parts.append(f"--{boundary}--\r\n".encode())
-    body = b"".join(parts)
-
-    headers = {
-        "Accept": "application/json",
-        "Authorization": f"Bearer {token}",
-        "Content-Type": f"multipart/form-data; boundary={boundary}",
-    }
-    req = Request(url=url, method="POST", headers=headers, data=body)
+            data[name] = value
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
     try:
-        with urlopen(req, timeout=120) as resp:
-            ctype = (resp.headers.get("Content-Type") or "").lower()
-            raw = resp.read()
-            if "application/json" in ctype:
-                try:
-                    return json.loads(raw.decode("utf-8"))
-                except Exception:
-                    return raw
-            return raw
-    except HTTPError as e:
-        body = e.read().decode("utf-8", errors="ignore")
-        print(f"[HTTP {e.code}] {body}", file=sys.stderr)
+        resp = _session.post(url, headers=headers, data=data, files=files, timeout=120)
+        resp.raise_for_status()
+        ctype = (resp.headers.get("Content-Type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                return resp.json()
+            except Exception:
+                return resp.content
+        return resp.content
+    except requests.HTTPError as e:
+        body = e.response.text if e.response is not None else ""
+        print(f"[HTTP {e.response.status_code if e.response else '??'}] {body}", file=sys.stderr)
         sys.exit(2)
-    except URLError as e:
-        print(f"Network error: {e.reason}", file=sys.stderr)
+    except requests.RequestException as e:
+        print(f"Network error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/yonote_cli/yonote_cli/core/utils.py
+++ b/yonote_cli/yonote_cli/core/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urljoin
 from typing import Any, Dict, List
 
 from .config import API_MAX_LIMIT
@@ -27,12 +28,21 @@ __all__ = ["fetch_all_concurrent", "format_rows", "safe_name", "ensure_text", "t
 
 
 
-def _post_page(base: str, token: str, endpoint: str, params: Dict[str, Any], limit: int, offset: int) -> Dict[str, Any]:
+def _post_page(
+    base: str,
+    token: str,
+    path: str,
+    params: Dict[str, Any],
+    limit: int,
+    offset: int | None,
+) -> Dict[str, Any]:
     if limit > API_MAX_LIMIT:
         limit = API_MAX_LIMIT
     payload = dict(params or {})
-    payload.update({"limit": limit, "offset": offset})
-    data = http_json("POST", f"{base}{endpoint}", token, payload)
+    if offset is not None:
+        payload.update({"limit": limit, "offset": offset})
+    url = urljoin(base, path)
+    data = http_json("POST", url, token, payload)
     if not isinstance(data, dict):
         return {"data": [], "pagination": {"total": 0}}
     if "data" not in data:
@@ -43,7 +53,7 @@ def _post_page(base: str, token: str, endpoint: str, params: Dict[str, Any], lim
 def fetch_all_concurrent(
     base: str,
     token: str,
-    endpoint: str,
+    path: str,
     *,
     params: Dict[str, Any] | None = None,
     limit: int = API_MAX_LIMIT,
@@ -54,26 +64,39 @@ def fetch_all_concurrent(
     limit = min(limit, API_MAX_LIMIT)
     params = dict(params or {})
 
-    first = _post_page(base, token, endpoint, params, limit, 0)
+    first = _post_page(base, token, path, params, limit, 0)
     items = list(first.get("data") or [])
     n_first = len(items)
 
-    if n_first < limit:
-        with tqdm(total=1, unit="pg", desc=desc) as bar:
-            bar.update(1)
-        return items
-
-    results: List[dict] = items
-    next_offset = limit
     with tqdm(total=None, unit="pg", desc=desc) as bar:
         bar.update(1)
-        while True:
-            offsets = list(range(next_offset, next_offset + limit * workers, limit))
-            if not offsets:
-                break
-            stop = False
+        pagination = first.get("pagination") or {}
+        next_path = pagination.get("nextPath")
+
+        # Sequential path-based pagination when server provides nextPath
+        if next_path:
+            results: List[dict] = items
             with ThreadPoolExecutor(max_workers=max(1, workers)) as ex:
-                futures = {ex.submit(_post_page, base, token, endpoint, params, limit, off): off for off in offsets}
+                while next_path:
+                    fut = ex.submit(_post_page, base, token, next_path, params, limit, None)
+                    data = fut.result()
+                    page_items = data.get("data") or []
+                    results.extend(page_items)
+                    bar.update(1)
+                    pagination = data.get("pagination") or {}
+                    next_path = pagination.get("nextPath")
+            return results
+
+        # Fallback to offset-based concurrent fetching
+        results: List[dict] = items
+        next_offset = limit
+        with ThreadPoolExecutor(max_workers=max(1, workers)) as ex:
+            while True:
+                offsets = list(range(next_offset, next_offset + limit * workers, limit))
+                if not offsets:
+                    break
+                stop = False
+                futures = {ex.submit(_post_page, base, token, path, params, limit, off): off for off in offsets}
                 for fut in as_completed(futures):
                     data = fut.result()
                     page_items = data.get("data") or []
@@ -81,10 +104,10 @@ def fetch_all_concurrent(
                     bar.update(1)
                     if len(page_items) < limit:
                         stop = True
-            next_offset += limit * workers
-            if stop:
-                break
-    return results
+                next_offset += limit * workers
+                if stop:
+                    break
+        return results
 
 
 def format_rows(rows: List[Dict[str, Any]], fields: List[str]) -> None:


### PR DESCRIPTION
## Summary
- follow `pagination.nextPath` when available, avoiding offset calculations
- reuse a single ThreadPoolExecutor for fetching pages
- keep connections alive via `requests.Session`

## Testing
- `pip install -e ./yonote_cli`
- `python -m py_compile $(git ls-files '*.py')`

