### PR TITLE
Add cross-platform release workflow and packaging docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install pyinstaller
+      - name: Run tests
+        run: pytest
       - name: Build executable
         run: |
           pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # yonote-tools — CLI для Yonote
 
+[![CI](https://github.com/teamfighter/yonote/actions/workflows/ci.yml/badge.svg)](https://github.com/teamfighter/yonote/actions/workflows/ci.yml)
+[![Release](https://github.com/teamfighter/yonote/actions/workflows/release.yml/badge.svg)](https://github.com/teamfighter/yonote/actions/workflows/release.yml)
+
 Инструмент командной строки для экспорта и импорта документов из платформы [Yonote](https://yonote.ru). CLI умеет интерактивно просматривать коллекции и документы, обновлять кэш выборочно и работать с вложенными папками.
 
 ## Установка
@@ -109,6 +112,12 @@ docker build -f docker/Dockerfile -t yonote:latest .
 Образ из релизов доступен в GitHub Container Registry:
 
 ```bash
-docker pull ghcr.io/<owner>/yonote:<tag>
+docker pull ghcr.io/teamfighter/yonote:<tag>
+```
+
+### Запуск тестов
+
+```bash
+pytest
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,8 @@
+import subprocess
+
+def test_cli_help():
+    result = subprocess.run([
+        "python", "-m", "yonote_cli.yonote_cli", "--help"
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Yonote CLI" in result.stdout


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and upload binaries for Linux, macOS and Windows
- publish Docker image to GitHub Container Registry on release
- document build and release process and add requirements.txt

## Testing
- `pip install -r requirements.txt pyinstaller`
- `pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile`
- `python -m py_compile $(git ls-files '*.py')`
- `docker build -f docker/Dockerfile .` *(fails: command not found)*