### PR TITLE
fix: improve CLI imports and build compatibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.12-slim
+# Build on Debian Bullseye (glibc 2.31) with Python 3.11 to produce binaries
+# that run on older Linux distributions.  Building on newer releases (e.g.
+# Python 3.12 base images) links against glibc 2.38, which fails on systems with
+# older libc versions.
+FROM python:3.11-slim-bullseye
 WORKDIR /app
 COPY yonote_cli ./yonote_cli
 RUN pip install -e ./yonote_cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
+pyinstaller
 pytest

--- a/yonote_cli/yonote_cli/__main__.py
+++ b/yonote_cli/yonote_cli/__main__.py
@@ -5,15 +5,30 @@ from __future__ import annotations
 import argparse
 import sys
 
-from .core import DEFAULT_BASE
-from .commands import (
-    cmd_auth_set,
-    cmd_auth_info,
-    cache_info,
-    cache_clear,
-    cmd_export,
-    cmd_import,
-)
+# Prefer absolute imports so the module works when bundled with tools like
+# PyInstaller.  When the package isn't installed (for example, when running
+# directly from a source checkout) fall back to relative imports so tests can
+# still invoke it using ``python -m``.
+try:  # pragma: no cover - exercised indirectly in tests
+    from yonote_cli.core import DEFAULT_BASE
+    from yonote_cli.commands import (
+        cmd_auth_set,
+        cmd_auth_info,
+        cache_info,
+        cache_clear,
+        cmd_export,
+        cmd_import,
+    )
+except ModuleNotFoundError:  # pragma: no cover
+    from .core import DEFAULT_BASE
+    from .commands import (
+        cmd_auth_set,
+        cmd_auth_info,
+        cache_info,
+        cache_clear,
+        cmd_export,
+        cmd_import,
+    )
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary
- allow CLI module to fall back to relative imports when package isn't installed
- add PyInstaller to requirements and note older Python base for releases
- build Linux images on Python 3.11 Bullseye to avoid glibc 2.38 dependency

## Testing
- `pytest -q`
- `python -m yonote_cli.yonote_cli --help`
