### PR TITLE
Add Docker-based build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install clean
+.PHONY: venv install clean build
 
 venv:
 	python3 -m venv .venv
@@ -9,3 +9,8 @@ install:
 
 clean:
 	rm -rf **/__pycache__ *.egg-info build dist
+
+build:
+	docker run --rm -v "$(PWD)":/src -w /src python:3.11-slim-bullseye \
+		bash -c "pip install -r requirements.txt && \
+		         pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile"

--- a/README.md
+++ b/README.md
@@ -95,17 +95,16 @@ yonote import --src-dir ./dump
 
 ### Локальная сборка бинарника
 
-Сборку лучше выполнять под Python 3.11 на базе Debian Bullseye, чтобы
-получившийся бинарник не требовал современную версию `glibc`. Самый простой
-способ — воспользоваться контейнером Docker:
+Чтобы готовый исполняемый файл работал на системах с более старой `glibc`,
+сборку необходимо выполнять в окружении Debian Bullseye с Python 3.11. Для
+упрощения добавлена цель `make build`, которая запускает PyInstaller внутри
+Docker-контейнера с подходящей версией `glibc`.
 
 ```bash
-docker run --rm -v "$PWD":/src -w /src python:3.11-slim-bullseye \
-    bash -c "pip install -r requirements.txt pyinstaller && \
-             pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile"
+make build
 ```
 
-Исполняемый файл появится в каталоге `dist/`.
+Результат появится в каталоге `dist/`.
 
 ### Локальная сборка Docker-образа
 


### PR DESCRIPTION
## Summary
- add `make build` target that runs PyInstaller inside a Debian Bullseye Python 3.11 container
- document the new build workflow in README

## Testing
- `pytest`
- `make build` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eb0423a8832a8ae832d5fea1bfba