### PR TITLE
refactor: drop binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,55 +5,6 @@ on:
     types: [published]
 
 jobs:
-  build:
-    name: Build binaries
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            artifact: yonote-linux
-            ext: ""
-          - os: macos-latest
-            artifact: yonote-macos
-            ext: ""
-          - os: windows-latest
-            artifact: yonote-windows.exe
-            ext: ".exe"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-      - name: Run tests
-        run: pytest
-      - name: Build executable (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          docker run --rm -v "$PWD":/src -w /src python:3.11-slim-bullseye \
-            bash -c "apt-get update && apt-get install -y binutils && \
-                     pip install -r requirements.txt && \
-                     pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile --collect-all InquirerPy"
-          mkdir release
-          mv dist/yonote release/${{ matrix.artifact }}
-        shell: bash
-      - name: Build executable (macOS/Windows)
-        if: matrix.os != 'ubuntu-latest'
-        run: |
-          pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile --collect-all InquirerPy
-          mkdir release
-          mv dist/yonote${{ matrix.ext }} release/${{ matrix.artifact }}
-        shell: bash
-      - name: Upload release asset
-        uses: softprops/action-gh-release@v1
-        with:
-          files: release/${{ matrix.artifact }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   docker:
     name: Docker image
     runs-on: ubuntu-latest
@@ -71,3 +22,12 @@ jobs:
           file: docker/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/yonote:${{ github.ref_name }}
+      - name: Update release notes
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            ${{ github.event.release.body }}
+
+            ```bash
+            docker pull ghcr.io/${{ github.repository_owner }}/yonote:${{ github.ref_name }}
+            ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install clean build
+.PHONY: venv install clean
 
 venv:
 	python3 -m venv .venv
@@ -10,8 +10,3 @@ install:
 clean:
 	rm -rf **/__pycache__ *.egg-info build dist
 
-build:
-	docker run --rm -v "$(PWD)":/src -w /src python:3.11-slim-bullseye \
-	        bash -c "apt-get update && apt-get install -y binutils && \
-	                       pip install -r requirements.txt && \
-	                       pyinstaller yonote_cli/yonote_cli/__main__.py --name yonote --onefile --collect-all InquirerPy"

--- a/README.md
+++ b/README.md
@@ -5,26 +5,35 @@
 
 Инструмент командной строки для экспорта и импорта документов из платформы [Yonote](https://yonote.ru). CLI умеет интерактивно просматривать коллекции и документы, обновлять кэш выборочно и работать с вложенными папками.
 
-## Установка
+## Запуск в Docker
+
+Образ публикуется в [GitHub Container Registry](https://github.com/orgs/teamfighter/packages).
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e yonote_cli
+docker pull ghcr.io/teamfighter/yonote:<tag>
 ```
 
-Или глобально:
+Для сохранения конфигурации и кэша смонтируйте файлы в домашний каталог контейнера и прокиньте рабочую директорию:
 
 ```bash
-pip install yonote-cli
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  -v "$(pwd):/data" \
+  ghcr.io/teamfighter/yonote:<tag> --help
 ```
+
+В примерах далее `ghcr.io/teamfighter/yonote:<tag>` следует запускать аналогичным образом.
 
 ## Настройка доступа
 
 Получите JWT‑токен в интерфейсе Yonote и сохраните параметры подключения:
 
 ```bash
-yonote auth set --base-url https://example.yonote.ru --token <JWT>
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  ghcr.io/teamfighter/yonote:<tag> auth set --base-url https://example.yonote.ru --token <JWT>
 ```
 
 Конфигурация хранится в `~/.yonote.json`, а кэш структуры документов — в `~/.yonote-cache.json`.
@@ -32,7 +41,11 @@ yonote auth set --base-url https://example.yonote.ru --token <JWT>
 ## Экспорт
 
 ```bash
-yonote export --out-dir ./dump --workers 4 --format md
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  -v "$(pwd)/dump:/data" \
+  ghcr.io/teamfighter/yonote:<tag> export --out-dir /data --workers 4 --format md
 ```
 
 Команда откроет встроенный браузер для выбора коллекций и документов. Выбранные элементы выгружаются в указанную директорию с сохранением иерархии. Полезные флаги:
@@ -44,7 +57,11 @@ yonote export --out-dir ./dump --workers 4 --format md
 ## Импорт
 
 ```bash
-yonote import --src-dir ./dump
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  -v "$(pwd)/dump:/data" \
+  ghcr.io/teamfighter/yonote:<tag> import --src-dir /data
 ```
 
 CLI предложит выбрать коллекцию и родительский документ, затем воспроизведёт локальную структуру каталогов в Yonote и опубликует созданные документы. Опции:
@@ -54,7 +71,7 @@ CLI предложит выбрать коллекцию и родительск
 
 ## Встроенный браузер
 
-Интерактивные диалоги экспорта и импорта используют встроенный браузер. Библиотека [InquirerPy](https://github.com/kazhala/InquirerPy), на которой он основан, включена в состав готовых бинарников, поэтому дополнительная установка не требуется. Доступные клавиши:
+Интерактивные диалоги экспорта и импорта используют встроенный браузер. Библиотека [InquirerPy](https://github.com/kazhala/InquirerPy), на которой он основан, уже включена в Docker‑образ, поэтому дополнительная установка не требуется. Доступные клавиши:
 
 - `↑`/`↓` — перемещение по списку;
 - `PgUp`/`PgDn` — пролистывание по 10 элементов;
@@ -69,8 +86,14 @@ CLI предложит выбрать коллекцию и родительск
 Метаданные коллекций и документов сохраняются в `~/.yonote-cache.json`. Управлять кэшем можно командами:
 
 ```bash
-yonote cache info   # показать информацию о кэше
-yonote cache clear  # очистить кэш
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  ghcr.io/teamfighter/yonote:<tag> cache info   # показать информацию о кэше
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  ghcr.io/teamfighter/yonote:<tag> cache clear  # очистить кэш
 ```
 
 Флаг `--refresh-cache` или сочетание `Ctrl+R` позволяют обновлять только нужные ветки дерева, сокращая время запросов.
@@ -80,48 +103,43 @@ yonote cache clear  # очистить кэш
 ### Экспорт коллекции в Markdown
 
 ```bash
-yonote export --out-dir ./dump --format md --workers 4
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  -v "$(pwd)/dump:/data" \
+  ghcr.io/teamfighter/yonote:<tag> export --out-dir /data --format md --workers 4
 ```
 
 ### Импорт подготовленных файлов
 
 ```bash
-yonote import --src-dir ./dump
+docker run --rm -it \
+  -v "$HOME/.yonote.json:/root/.yonote.json" \
+  -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+  -v "$(pwd)/dump:/data" \
+  ghcr.io/teamfighter/yonote:<tag> import --src-dir /data
 ```
 
-## Сборка и релизы
+Команда для загрузки образа с конкретной версией публикуется в релизных заметках.
 
-Список зависимостей находится в файле `requirements.txt`. Готовые бинарники для Linux, macOS и Windows, а также Docker-образ публикуются автоматически при создании релиза на GitHub.
-
-### Локальная сборка бинарника
-
-Чтобы готовый исполняемый файл работал на системах с более старой `glibc`,
-сборку необходимо выполнять в окружении Debian Bullseye с Python 3.11. Для
-упрощения добавлена цель `make build`, которая запускает PyInstaller внутри
-Docker-контейнера с подходящей версией `glibc` и устанавливает пакет `binutils`
-для доступности `objdump`.
+## Локальная разработка
 
 ```bash
-make build
-```
-
-Результат появится в каталоге `dist/`.
-
-### Локальная сборка Docker-образа
-
-```bash
-docker build -f docker/Dockerfile -t yonote:latest .
-```
-
-Образ из релизов доступен в GitHub Container Registry:
-
-```bash
-docker pull ghcr.io/teamfighter/yonote:<tag>
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e yonote_cli
 ```
 
 ### Запуск тестов
 
 ```bash
 pytest
+```
+
+### Сборка Docker-образа
+
+```bash
+docker build -f docker/Dockerfile -t yonote:dev .
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,4 @@
-# Build on Debian Bullseye (glibc 2.31) with Python 3.11 to produce binaries
-# that run on older Linux distributions.  Building on newer releases (e.g.
-# Python 3.12 base images) links against glibc 2.38, which fails on systems with
-# older libc versions.
+# Base on Debian Bullseye (glibc 2.31) with Python 3.11 for compatibility with older Linux distributions.
 FROM python:3.11-slim-bullseye
 WORKDIR /app
 COPY yonote_cli ./yonote_cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 InquirerPy
-pyinstaller
 pytest

--- a/yonote_cli/yonote_cli/__main__.py
+++ b/yonote_cli/yonote_cli/__main__.py
@@ -6,13 +6,10 @@ import argparse
 import os
 import sys
 
-# Prefer absolute imports so the module works when bundled with tools like
-# PyInstaller.  When the package isn't installed (for example, when running
-# directly from a source checkout) fall back to relative imports so tests can
-
-# still invoke it using ``python -m``.  When executed from a PyInstaller bundle
-# ``__package__`` is ``None`` which breaks relative imports, so we set it and
-# add this file's directory to ``sys.path`` before importing.
+# Prefer absolute imports so the module works when installed as a package.
+# When running directly from a source checkout fall back to relative imports so
+# tests can invoke it using ``python -m``. If ``__package__`` is ``None`` we set
+# it and add this file's directory to ``sys.path`` before importing.
 try:  # pragma: no cover - exercised indirectly in tests
     from yonote_cli.core import DEFAULT_BASE
     from yonote_cli.commands import (


### PR DESCRIPTION
## Summary
- distribute CLI exclusively as a Docker image
- simplify build tooling and dependencies
- document container usage and developer setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30d0b1388832a8ae341b1ea7d1af9