### PR TITLE
Avoid directory creation for Yonote config files in wrapper

### DIFF
--- a/yonote.sh
+++ b/yonote.sh
@@ -4,6 +4,25 @@
 
 # Function to run Yonote CLI in Docker with proper mounts
 yonote() {
+  # Ensure config and cache files exist so Docker mounts them as files rather than
+  # creating directories. Without these placeholders Docker would create
+  # directories which leads to IsADirectoryError inside the container when the
+  # CLI tries to write to the JSON files.
+  if [ -d "$HOME/.yonote.json" ]; then
+    echo "Error: $HOME/.yonote.json is a directory. Remove or rename it." >&2
+    return 1
+  fi
+  if [ -d "$HOME/.yonote-cache.json" ]; then
+    echo "Error: $HOME/.yonote-cache.json is a directory. Remove or rename it." >&2
+    return 1
+  fi
+  if [ ! -e "$HOME/.yonote.json" ]; then
+    touch "$HOME/.yonote.json"
+  fi
+  if [ ! -e "$HOME/.yonote-cache.json" ]; then
+    touch "$HOME/.yonote-cache.json"
+  fi
+
   docker run --rm -it \
     -v "$HOME/.yonote.json:/root/.yonote.json" \
     -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \


### PR DESCRIPTION
## Summary
- Ensure `yonote.sh` creates placeholder config files before running Docker
- Warn when config paths are directories instead of files to prevent IsADirectoryError

## Testing
- `bash -n yonote.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a335d2f364832a9f23fb231b395e85