### PR TITLE
feat(cli): add diagnostic commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,3 +6,12 @@ def test_cli_help():
     ], capture_output=True, text=True)
     assert result.returncode == 0
     assert "Yonote CLI" in result.stdout
+
+
+def test_diag_help():
+    result = subprocess.run([
+        "python", "-m", "yonote_cli.yonote_cli", "diag", "--help"
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "List collections" in result.stdout
+    assert "List documents" in result.stdout

--- a/yonote_cli/yonote_cli/__main__.py
+++ b/yonote_cli/yonote_cli/__main__.py
@@ -19,6 +19,8 @@ try:  # pragma: no cover - exercised indirectly in tests
         cache_clear,
         cmd_export,
         cmd_import,
+        cmd_diag_collections,
+        cmd_diag_documents,
     )
 except ModuleNotFoundError:  # pragma: no cover
     if __package__ in (None, ""):
@@ -32,6 +34,8 @@ except ModuleNotFoundError:  # pragma: no cover
         cache_clear,
         cmd_export,
         cmd_import,
+        cmd_diag_collections,
+        cmd_diag_documents,
     )
 
 
@@ -58,6 +62,19 @@ def main(argv=None):
     p_cache_info.set_defaults(func=cache_info)
     p_cache_clear = sub_cache.add_parser("clear", help="Delete cache file")
     p_cache_clear.set_defaults(func=cache_clear)
+
+    # diagnostic
+    p_diag = sub.add_parser("diag", help="Diagnostic API calls")
+    sub_diag = p_diag.add_subparsers(dest="diag_cmd")
+
+    p_diag_cols = sub_diag.add_parser("collections", help="List collections")
+    p_diag_cols.add_argument("--workers", type=int, default=4, help="Parallel workers")
+    p_diag_cols.set_defaults(func=cmd_diag_collections)
+
+    p_diag_docs = sub_diag.add_parser("documents", help="List documents in a collection")
+    p_diag_docs.add_argument("--collection-id", required=True, help="Collection ID")
+    p_diag_docs.add_argument("--workers", type=int, default=4, help="Parallel workers")
+    p_diag_docs.set_defaults(func=cmd_diag_documents)
 
     # unified export
     p_exp = sub.add_parser("export", help="Interactive export of documents/collections")
@@ -103,6 +120,9 @@ def main(argv=None):
         return 0
     if args.cmd == "cache" and not getattr(args, "cache_cmd", None):
         p_cache.print_help()
+        return 0
+    if args.cmd == "diag" and not getattr(args, "diag_cmd", None):
+        p_diag.print_help()
         return 0
     return args.func(args)
 

--- a/yonote_cli/yonote_cli/commands/__init__.py
+++ b/yonote_cli/yonote_cli/commands/__init__.py
@@ -4,6 +4,7 @@ from .auth import cmd_auth_set, cmd_auth_info
 from .cache import cache_info, cache_clear
 from .export import cmd_export
 from .import_cmd import cmd_import
+from .diag import cmd_diag_collections, cmd_diag_documents
 
 __all__ = [
     "cmd_auth_set",
@@ -12,4 +13,6 @@ __all__ = [
     "cache_clear",
     "cmd_export",
     "cmd_import",
+    "cmd_diag_collections",
+    "cmd_diag_documents",
 ]

--- a/yonote_cli/yonote_cli/commands/diag.py
+++ b/yonote_cli/yonote_cli/commands/diag.py
@@ -1,0 +1,32 @@
+"""Diagnostic commands for listing collections and documents."""
+
+from __future__ import annotations
+
+import json
+
+from ..core import get_base_and_token, list_collections, list_documents_in_collection
+
+
+def cmd_diag_collections(args):
+    base, token = get_base_and_token()
+    cols = list_collections(
+        base,
+        token,
+        use_cache=False,
+        refresh_cache=True,
+        workers=getattr(args, "workers", 4),
+    )
+    print(json.dumps(cols, ensure_ascii=False, indent=2))
+
+
+def cmd_diag_documents(args):
+    base, token = get_base_and_token()
+    docs = list_documents_in_collection(
+        base,
+        token,
+        args.collection_id,
+        use_cache=False,
+        refresh_cache=True,
+        workers=getattr(args, "workers", 4),
+    )
+    print(json.dumps(docs, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- add `diag` CLI command for listing collections and documents via API
- include diagnostic handlers in command registry
- test new CLI help output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33f7bd400832abc3eea0d6c3d2fab