### PR TITLE
Fix search shortcut keybindings in interactive prompts

### DIFF
--- a/yonote_cli/yonote_cli/core/interactive.py
+++ b/yonote_cli/yonote_cli/core/interactive.py
@@ -338,7 +338,7 @@ def interactive_browse_for_export(
                         inquirer.text(
                             message="Поиск:",
                             default=search["query"] or "",
-                            keybindings={"submit": [{"key": "c-s"}]},
+                            keybindings={"answer": [{"key": "c-s"}]},
                         )
                     )
                     search["query"] = q or None
@@ -447,7 +447,7 @@ def interactive_browse_for_export(
                 inquirer.text(
                     message="Поиск:",
                     default=search["query"] or "",
-                    keybindings={"submit": [{"key": "c-s"}]},
+                    keybindings={"answer": [{"key": "c-s"}]},
                 )
             )
             search["query"] = q or None
@@ -628,7 +628,7 @@ def interactive_pick_destination(
                         inquirer.text(
                             message="Поиск:",
                             default=search["query"] or "",
-                            keybindings={"submit": [{"key": "c-s"}]},
+                            keybindings={"answer": [{"key": "c-s"}]},
                         )
                     )
                     search["query"] = q or None
@@ -733,7 +733,7 @@ def interactive_pick_destination(
                 inquirer.text(
                     message="Поиск:",
                     default=search["query"] or "",
-                    keybindings={"submit": [{"key": "c-s"}]},
+                    keybindings={"answer": [{"key": "c-s"}]},
                 )
             )
             search["query"] = q or None


### PR DESCRIPTION
## Summary
- replace obsolete `submit` action with `answer` in search prompts so Ctrl+S works during import/export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f867c580832abb124e934ada79c9