### PR TITLE
Run docker container as host user in yonote.sh

### DIFF
--- a/yonote.sh
+++ b/yonote.sh
@@ -24,8 +24,10 @@ yonote() {
   fi
 
   docker run --rm -it \
-    -v "$HOME/.yonote.json:/root/.yonote.json" \
-    -v "$HOME/.yonote-cache.json:/root/.yonote-cache.json" \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -v "$HOME/.yonote.json:/tmp/.yonote.json" \
+    -v "$HOME/.yonote-cache.json:/tmp/.yonote-cache.json" \
     -v "$(pwd):/app/work" \
     -w /app/work \
     ghcr.io/teamfighter/yonote:${YONOTE_VERSION:-latest} "$@"


### PR DESCRIPTION
## Summary
- Ensure `yonote.sh` runs Docker container as the invoking host user
- Mount config files under `/tmp` and adjust `HOME` so export directories aren't owned by root

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59a22c960832aa13f9cf8c374fa0a