### PR TITLE
ci: allow Docker pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   docker:


### PR DESCRIPTION
## Summary
- add `packages: write` permission to release workflow so Docker image can be pushed

## Testing
- `pytest`
- `act -W .github/workflows/release.yml -j docker` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a129247c832a9fe614f6a1a074cd